### PR TITLE
avoid using abandoned package sparkpost/php-sparkpost

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require": {
     "php": ">=5.5.0",
     "guzzlehttp/guzzle": "~6.0",
-    "sparkpost/php-sparkpost": "^1.0"
+    "sparkpost/sparkpost": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.4",


### PR DESCRIPTION
`composer install` says:
`Package sparkpost/php-sparkpost is abandoned, you should avoid using it. Use sparkpost/sparkpost instead.`
